### PR TITLE
Adding support for item at Belt and Torso

### DIFF
--- a/Source/Sandy_Detailed_RPG_Inventory/MyClass.cs
+++ b/Source/Sandy_Detailed_RPG_Inventory/MyClass.cs
@@ -276,6 +276,11 @@ namespace Sandy_Detailed_RPG_Inventory
 						this.DrawThingRow1(newRect, current2, false);
 					}
 					//Belt
+					else if (current2.def.apparel.layers.Contains(ApparelLayerDefOf.Belt) && current2.def.apparel.bodyPartGroups.Contains(Sandy_Gear_DefOf.Shoulders))
+					{
+						Rect newRect = new Rect(76f, 222f, 64f, 64f);
+						this.DrawThingRow1(newRect, current2, false);
+					}
 					else if (current2.def.apparel.layers.Contains(ApparelLayerDefOf.Belt))
 					{
 						Rect newRect = new Rect(150f, 222f, 64f, 64f);

--- a/Source_1.1/Sandy_Detailed_RPG_Inventory/Sandy_Detailed_RPG_Inventory/MyClass.cs
+++ b/Source_1.1/Sandy_Detailed_RPG_Inventory/Sandy_Detailed_RPG_Inventory/MyClass.cs
@@ -282,6 +282,10 @@ namespace Sandy_Detailed_RPG_Inventory
 							Rect newRectBe = new Rect(150f, 222f, 64f, 64f);
 							this.DrawThingRow1(newRectBe, current2, false);
 							break;
+						case ApparelProperties a when (a.bodyPartGroups.Contains(Sandy_Gear_DefOf.Torso) && a.layers.Contains(ApparelLayerDefOf.Belt)):
+							Rect newRectBe = new Rect(76f, 222f, 64f, 64f);
+							this.DrawThingRow1(newRectBe, current2, false);
+							break;
 
 						//Jetpack
 						case ApparelProperties a when (a.bodyPartGroups.Contains(Sandy_Gear_DefOf.Waist) && a.layers.Contains(ApparelLayerDefOf.Shell)):


### PR DESCRIPTION
This is is to support my FieldMedic mod, where the medic bag covers Torso and Shoulders at Belt layer. The spot I put the item is currently not used by anything, right next to the Shield/Smoke belt's slot.

I HAVEN'T recompile the dll since on my local machine Git believes a lot of files have changes when they are not (maybe tab to space or LF to CRLF, I can't tell...), and I don't want to screw up this repo.